### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,8 +13,8 @@ LTM8328PKR04	KEYWORD1
 #######################################
 
 print	KEYWORD2
-setLeadingZeros KEYWORD2
-clear KEYWORD2
+setLeadingZeros	KEYWORD2
+clear	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords